### PR TITLE
If the cell value is an array do not stringify it, instead use the ar…

### DIFF
--- a/src/js/modules/download.js
+++ b/src/js/modules/download.js
@@ -816,7 +816,12 @@ Download.prototype.downloaders = {
 
 				fields.forEach(function(field){
 					var value = self.getFieldValue(field, row);
-					rowData.push(!(value instanceof Date) && typeof value === "object" ? JSON.stringify(value) : value);
+					if(Array.isArray(value)){
+						rowData.push(value);
+					}
+					else{
+						rowData.push(!(value instanceof Date) && typeof value === "object" ? JSON.stringify(value) : value);
+					}
 				});
 
 				return rowData;


### PR DESCRIPTION
…ray value. SheetJS supports this syntax and can parse formulas out of the first index.

https://github.com/olifolkerd/tabulator/issues/2648